### PR TITLE
Fix funnel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package can be installed by adding `membrane_ice_plugin` to your list of dep
 ```elixir
 def deps do
   [
-    {:membrane_ice_plugin, "~> 0.3.0"}
+    {:membrane_ice_plugin, "~> 0.3.1"}
   ]
 end
 ```

--- a/lib/membrane_ice_plugin/sink.ex
+++ b/lib/membrane_ice_plugin/sink.ex
@@ -40,9 +40,13 @@ defmodule Membrane.ICE.Sink do
 
   @impl true
   def handle_event(Pad.ref(:input, component_id) = pad, %Funnel.NewInputEvent{}, _ctx, state) do
-    handshake_data = state.ready_components[component_id]
-    event = {pad, %Handshake.Event{handshake_data: handshake_data}}
-    {{:ok, event: event}, state}
+    if Map.has_key?(state.ready_components, component_id) do
+      handshake_data = state.ready_components[component_id]
+      event = {pad, %Handshake.Event{handshake_data: handshake_data}}
+      {{:ok, event: event}, state}
+    else
+      {:ok, state}
+    end
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.ICE.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @github_url "https://github.com/membraneframework/membrane_ice_plugin"
 
   def project do


### PR DESCRIPTION
This PR fixes support for Funnel plugin. There was a race condition when someone linked to funnel before ICE Sink received data from handshake.  