### PR TITLE
Connection establishment enhancements

### DIFF
--- a/lib/membrane_ice_plugin/connector.ex
+++ b/lib/membrane_ice_plugin/connector.ex
@@ -92,7 +92,7 @@ defmodule Membrane.ICE.Connector do
     GenServer.call(pid, {:set_remote_candidate, candidate, component_id})
   end
 
-  @spec restart_stream(connector :: pid()) :: :ok
+  @spec restart_stream(connector :: pid()) :: {:ok, credentials: String.t()}
   def restart_stream(pid) do
     GenServer.call(pid, :restart_stream)
   end

--- a/lib/membrane_ice_plugin/connector.ex
+++ b/lib/membrane_ice_plugin/connector.ex
@@ -375,23 +375,20 @@ defmodule Membrane.ICE.Connector do
       :ok ->
         {{false, nil}, state}
 
-      {:ok, <<>>} ->
-        {{false, nil}, state}
-
       {:ok, packets} ->
         ExLibnice.send_payload(ice, stream_id, component_id, packets)
         {{false, nil}, state}
 
-      {:finished_with_packets, handshake_data, packets} ->
-        ExLibnice.send_payload(ice, stream_id, component_id, packets)
-
+      {:finished, handshake_data} ->
         handshakes =
           Map.put(handshakes, component_id, {handshake_status, :finished, handshake_data})
 
         new_state = %State{state | handshakes: handshakes}
         {{true, handshake_data}, new_state}
 
-      {:finished, handshake_data} ->
+      {:finished, handshake_data, packets} ->
+        ExLibnice.send_payload(ice, stream_id, component_id, packets)
+
         handshakes =
           Map.put(handshakes, component_id, {handshake_status, :finished, handshake_data})
 

--- a/lib/membrane_ice_plugin/connector.ex
+++ b/lib/membrane_ice_plugin/connector.ex
@@ -364,6 +364,9 @@ defmodule Membrane.ICE.Connector do
       :ok ->
         {{false, nil}, state}
 
+      {:ok, <<>>} ->
+        {{false, nil}, state}
+
       {:ok, packets} ->
         ExLibnice.send_payload(ice, stream_id, component_id, packets)
         {{false, nil}, state}

--- a/lib/membrane_ice_plugin/connector.ex
+++ b/lib/membrane_ice_plugin/connector.ex
@@ -177,6 +177,17 @@ defmodule Membrane.ICE.Connector do
 
   @impl true
   def handle_call(
+        {:set_remote_candidate, "a=", _component_id},
+        _from,
+        %State{ice: ice, stream_id: stream_id} = state
+      ) do
+    # sending an empty candidate means end of peer's gathering process
+    ExLibnice.peer_candidate_gathering_done(ice, stream_id)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(
         {:set_remote_candidate, candidate, component_id},
         _from,
         %State{ice: ice, stream_id: stream_id} = state

--- a/lib/membrane_ice_plugin/handshake/handshake.ex
+++ b/lib/membrane_ice_plugin/handshake/handshake.ex
@@ -44,14 +44,19 @@ defmodule Membrane.ICE.Handshake do
   @callback connection_ready(state :: state()) ::
               :ok
               | {:ok, packets :: binary()}
-              | {:finished_with_packets, handshake_data :: term(), packets :: binary()}
+              | {:finished, handshake_data :: term(), packets :: binary()}
               | {:finished, handshake_data :: term()}
 
   @doc """
   Called each time remote data arrives.
 
+  Message `:ok` should be returned when peer processed incoming data without generating a new one.
+
   Message `{:ok, packets}` should be returned when peer processed incoming data and generated
   a new one.
+
+  If packets cannot be immediately sent (because ICE is not ready yet) they will be cached and
+  send as soon as it is possible (i.e. when ICE is ready).
 
   Message `{:finished_with_packets, handshake_data, packets}` should be return by a peer that ends
   its handshake first but it generates also some final packets so that the second peer can end its
@@ -64,7 +69,8 @@ defmodule Membrane.ICE.Handshake do
   `handshake_data` is any data user want to return after finishing handshake.
   """
   @callback recv_from_peer(state :: state(), data :: binary()) ::
-              {:ok, packets :: binary()}
-              | {:finished_with_packets, handshake_data :: term(), packets :: binary()}
+              :ok
+              | {:ok, packets :: binary()}
+              | {:finished, handshake_data :: term(), packets :: binary()}
               | {:finished, handshake_data :: term()}
 end

--- a/lib/membrane_ice_plugin/handshake/handshake.ex
+++ b/lib/membrane_ice_plugin/handshake/handshake.ex
@@ -56,7 +56,7 @@ defmodule Membrane.ICE.Handshake do
   a new one.
 
   If packets cannot be immediately sent (because ICE is not ready yet) they will be cached and
-  send as soon as it is possible (i.e. when ICE is ready).
+  sent as soon as it is possible (i.e. when ICE is ready).
 
   Message `{:finished_with_packets, handshake_data, packets}` should be return by a peer that ends
   its handshake first but it generates also some final packets so that the second peer can end its

--- a/lib/membrane_ice_plugin/ice_bin.ex
+++ b/lib/membrane_ice_plugin/ice_bin.ex
@@ -33,7 +33,7 @@ defmodule Membrane.ICE.Bin do
   - `{:set_remote_credentials, credentials}` - credentials are string in form of "ufrag passwd"
 
   - `{:set_remote_candidate, candidate, component_id}` - candidate is a string in form of
-  SDP attribute i.e. it has prefix "a=" e.g. "a=candidate 1 " #TODO
+  SDP attribute i.e. it has prefix "a=" e.g. "a=candidate 1 "
 
   - `{:parse_remote_sdp, sdp}`
 


### PR DESCRIPTION
* don't try to send empty packets
* handle peer's end-of-candidates indication 
* cache handshake packets if ICE is not ready yet
* unify Handshake behaviour API