### PR TITLE
Update dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Membrane.ICE.Plugin.Mixfile do
     [
       {:membrane_core, "~> 0.6.1"},
       {:unifex, "~> 0.3.2"},
-      {:ex_libnice, github: "membraneframework/ex_libnice", branch: "ice-restart"},
+      {:ex_libnice, github: "membraneframework/ex_libnice", branch: "master"},
       {:membrane_funnel_plugin, "~> 0.1.0"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Branch `ice-restart` no longer exists for the `ex_libnice` package