### PR TITLE
remove log_metadata option from ICE.Bin

### DIFF
--- a/lib/membrane_ice_plugin/ice_bin.ex
+++ b/lib/membrane_ice_plugin/ice_bin.ex
@@ -102,12 +102,6 @@ defmodule Membrane.ICE.Bin do
                 default: [],
                 description:
                   "Options for handshake module. They will be passed to init function of hsk_module"
-              ],
-              log_metadata: [
-                spec: :list,
-                spec: Keyword.t(),
-                default: [],
-                description: "Logger metadata used for ice bin and all its descendants"
               ]
 
   def_input_pad :input,


### PR DESCRIPTION
`log_metadata` option seems to be unused.