### PR TITLE
Move cleanup from `handle_shutdown` to a separate process

### DIFF
--- a/lib/membrane_ice_plugin/application.ex
+++ b/lib/membrane_ice_plugin/application.ex
@@ -18,7 +18,8 @@ defmodule Membrane.ICE.Application do
       %{
         id: TURNManager,
         start: {TURNManager, :start_link, []}
-      }
+      },
+      {DynamicSupervisor, strategy: :one_for_one, name: Membrane.ICE.TURNCleaner.Sup}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)

--- a/lib/membrane_ice_plugin/ice_endpoint.ex
+++ b/lib/membrane_ice_plugin/ice_endpoint.ex
@@ -222,8 +222,8 @@ defmodule Membrane.ICE.Endpoint do
         {:ok, _pid} =
           Membrane.ICE.TURNCleaner.start_under(
             state.turn_cleaner_sup,
-            pid: self(),
-            turn: udp_integrated_turn
+            self(),
+            udp_integrated_turn
           )
 
         state =
@@ -265,8 +265,8 @@ defmodule Membrane.ICE.Endpoint do
         {:ok, _pid} =
           Membrane.ICE.TURNCleaner.start_under(
             state.turn_cleaner_sup,
-            pid: self(),
-            turn: udp_integrated_turn
+            self(),
+            udp_integrated_turn
           )
 
         state =

--- a/lib/membrane_ice_plugin/turn_cleaner.ex
+++ b/lib/membrane_ice_plugin/turn_cleaner.ex
@@ -1,0 +1,49 @@
+defmodule Membrane.ICE.TURNCleaner do
+  @moduledoc """
+  Integrated TURN cleaner.
+
+  It monitors given process and when it exits, stops Integrated TURN.
+  """
+  use GenServer, restart: :transient
+
+  @typedoc """
+  * `pid` - pid to monitor
+  * `turn` - TURN server to terminate when process with pid `pid` exits
+  """
+  @type init_arg() :: [pid: pid(), turn: map()]
+
+  @doc """
+  Starts and links Integrated TURN cleaner to calling process.
+  """
+  @spec start_link(init_arg()) :: GenServer.on_start()
+  def start_link(init_arg) do
+    GenServer.start_link(__MODULE__, init_arg)
+  end
+
+  @doc """
+  Spawns new `Membrane.ICE.TurnCleaner` under supervisor `supervisor`.
+  """
+  @spec start_under(Supervisor.supervisor(), init_arg()) :: DynamicSupervisor.on_start_child()
+  def start_under(supervisor, init_arg) do
+    DynamicSupervisor.start_child(
+      supervisor,
+      {__MODULE__, init_arg}
+    )
+  end
+
+  @impl true
+  def init(pid: pid, turn: turn) do
+    pid_monitor = Process.monitor(pid)
+    state = %{pid_monitor: pid_monitor, pid: pid, turn: turn}
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(
+        {:DOWN, pid_monitor, :process, pid, _reason},
+        %{pid_monitor: pid_monitor, pid: pid, turn: turn} = state
+      ) do
+    Membrane.ICE.Utils.stop_integrated_turn(turn)
+    {:stop, :normal, state}
+  end
+end

--- a/lib/membrane_ice_plugin/turn_cleaner.ex
+++ b/lib/membrane_ice_plugin/turn_cleaner.ex
@@ -16,10 +16,10 @@ defmodule Membrane.ICE.TURNCleaner do
     cleaner_pid =
       Process.spawn(
         fn ->
-          pid_monitor = Process.monitor(pid)
+          monitor_ref = Process.monitor(pid)
 
           receive do
-            {:DOWN, ^pid_monitor, :process, ^pid, _reason} ->
+            {:DOWN, ^monitor_ref, :process, ^pid, _reason} ->
               Membrane.ICE.Utils.stop_integrated_turn(turn)
           end
         end,
@@ -30,7 +30,7 @@ defmodule Membrane.ICE.TURNCleaner do
   end
 
   @doc """
-  Spawns new `Membrane.ICE.TurnCleaner` under supervisor `supervisor`.
+  Spawns a new TURN cleaner under supervisor `supervisor`.
 
   `pid` and `turn` have the same meaning as in `start_link/2`.
   """

--- a/test/membrane_ice_plugin/integration_test.exs
+++ b/test/membrane_ice_plugin/integration_test.exs
@@ -97,5 +97,7 @@ defmodule Membrane.ICE.IntegrationTest do
     assert username == stun_msg[:username]
 
     assert_pipeline_notified(pid, :ice, {:connection_ready, @stream_id, @component_id})
+
+    Testing.Pipeline.terminate(pid, blocking?: true)
   end
 end

--- a/test/membrane_ice_plugin/turn_cleaner_test.exs
+++ b/test/membrane_ice_plugin/turn_cleaner_test.exs
@@ -6,6 +6,9 @@ defmodule Membrane.ICE.TURNCleanerTest do
   test "TURNCleaner is created and destroyed properly" do
     turn_cleaner_sup = start_supervised!({DynamicSupervisor, strategy: :one_for_one})
 
+    assert %{specs: 0, active: 0, supervisors: 0, workers: 0} ==
+             DynamicSupervisor.count_children(turn_cleaner_sup)
+
     children = [
       ice_endpoint: %Membrane.ICE.Endpoint{
         dtls?: false,

--- a/test/membrane_ice_plugin/turn_cleaner_test.exs
+++ b/test/membrane_ice_plugin/turn_cleaner_test.exs
@@ -21,10 +21,14 @@ defmodule Membrane.ICE.TURNCleanerTest do
     assert %{specs: 1, active: 1, supervisors: 0, workers: 1} ==
              DynamicSupervisor.count_children(turn_cleaner_sup)
 
+    [{:undefined, turn_cleaner_pid, :worker, _modules}] =
+      DynamicSupervisor.which_children(turn_cleaner_sup)
+
+    m_ref = Process.monitor(turn_cleaner_pid)
+
     :ok = Membrane.Testing.Pipeline.terminate(pipeline, blocking?: true)
 
-    # give TURN cleaner some time to exit
-    Process.sleep(100)
+    assert_receive {:DOWN, ^m_ref, :process, ^turn_cleaner_pid, :normal}
 
     assert %{specs: 0, active: 0, supervisors: 0, workers: 0} ==
              DynamicSupervisor.count_children(turn_cleaner_sup)

--- a/test/membrane_ice_plugin/turn_cleaner_test.exs
+++ b/test/membrane_ice_plugin/turn_cleaner_test.exs
@@ -1,0 +1,32 @@
+defmodule Membrane.ICE.TURNCleanerTest do
+  use ExUnit.Case
+
+  import Membrane.Testing.Assertions
+
+  test "TURNCleaner is created and destroyed properly" do
+    turn_cleaner_sup = start_supervised!({DynamicSupervisor, strategy: :one_for_one})
+
+    children = [
+      ice_endpoint: %Membrane.ICE.Endpoint{
+        dtls?: false,
+        integrated_turn_options: [ip: {127, 0, 0, 1}],
+        turn_cleaner_sup: turn_cleaner_sup
+      }
+    ]
+
+    {:ok, pipeline} = Membrane.Testing.Pipeline.start_link(children: children)
+
+    assert_pipeline_playback_changed(pipeline, :prepared, :playing)
+
+    assert %{specs: 1, active: 1, supervisors: 0, workers: 1} ==
+             DynamicSupervisor.count_children(turn_cleaner_sup)
+
+    :ok = Membrane.Testing.Pipeline.terminate(pipeline, blocking?: true)
+
+    # give TURN cleaner some time to exit
+    Process.sleep(100)
+
+    assert %{specs: 0, active: 0, supervisors: 0, workers: 0} ==
+             DynamicSupervisor.count_children(turn_cleaner_sup)
+  end
+end


### PR DESCRIPTION
`handle_shutdown` might not always be called. This PR moves critical socket cleanup to a separate process.