### PR TITLE
[RTC-23] Ice Endpoint demands in `:prepared` playback state

### DIFF
--- a/lib/membrane_ice_plugin/ice_endpoint.ex
+++ b/lib/membrane_ice_plugin/ice_endpoint.ex
@@ -729,7 +729,7 @@ defmodule Membrane.ICE.Endpoint do
   defp maybe_send_demands_actions(ctx, state) do
     pad = Pad.ref(:input, @component_id)
     # if something is linked, component is ready and handshake is done then send demands
-    if Map.has_key?(ctx.pads, pad) and state.component_ready? and
+    if ctx.playback_state == :playing and Map.has_key?(ctx.pads, pad) and state.component_ready? and
          state.handshake.status == :finished do
       event = if state.dtls?, do: [event: {pad, state.handshake.keying_material_event}], else: []
       event ++ [demand: pad]

--- a/lib/membrane_ice_plugin/utils.ex
+++ b/lib/membrane_ice_plugin/utils.ex
@@ -96,7 +96,7 @@ defmodule Membrane.ICE.Utils do
   def generate_ice_pwd(), do: random_readable_binary(22)
 
   @spec is_dtls_hsk_packet(binary()) :: boolean()
-  def is_dtls_hsk_packet(<<head, _rest::binary()>> = packet),
+  def is_dtls_hsk_packet(<<head, _rest::binary>> = packet),
     do: head in 20..63 and byte_size(packet) >= 13
 
   @spec start_integrated_turn_servers(


### PR DESCRIPTION
It seems that during testing of our WebRTC implementation in production environment, a obscure race condition was discovered, as described in [RTC-23](https://membraneframework.atlassian.net/browse/RTC-23).
```
[:ice] Error handling action {:demand, {Membrane.Pad, :input, 1}} returned by callback Membrane.ICE.Endpoint.handle_other
```

I think we received `:handshake_finished` after transitioning to state `:prepared`. I don't think the fact we received this message is a problem, but we shouldn't send demands as a result, therefore, I have added a `playback_state == :playing` check in `maybe_send_demands_actions`. I don't think any changes are required as a result of this one.
