### PR TITLE
Fix typo

### DIFF
--- a/lib/membrane_ice_plugin/ice_endpoint.ex
+++ b/lib/membrane_ice_plugin/ice_endpoint.ex
@@ -439,7 +439,7 @@ defmodule Membrane.ICE.Endpoint do
   end
 
   @impl true
-  def handle_info({:alloc_deleted, alloc_pid}, _ctx, state) do
+  def handle_info({:alloc_deleting, alloc_pid}, _ctx, state) do
     Membrane.Logger.debug("Deleting allocation with pid #{inspect(alloc_pid)}")
     {_alloc, state} = pop_in(state, [:turn_allocs, alloc_pid])
     {[], state}


### PR DESCRIPTION
[Current master of `fake_turn`](https://github.com/jellyfish-dev/fake_turn/blob/1a7bc2896033b4db95bbd8d8e78d27df741cc294/src/turn.erl#L456) sends `alloc_deleting` instead of `alloc_deleted`.