### PR TITLE
Add indication debug status

### DIFF
--- a/lib/membrane_ice_plugin/ice_endpoint.ex
+++ b/lib/membrane_ice_plugin/ice_endpoint.ex
@@ -638,6 +638,7 @@ defmodule Membrane.ICE.Endpoint do
         :response -> "Success"
         :request -> "Request"
         :error -> "Error"
+        :indication -> "Indication"
       end
 
     Map.delete(attrs, :class)


### PR DESCRIPTION
When implementing WebRTC, we've found that the indication message is not handled for debug logging. This fixes that issue. 